### PR TITLE
[DO NOT MERGE] Frontend port changes

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "xstate": "^4.9.1"
   },
   "scripts": {
-    "start": "PORT=3001 react-scripts start",
+    "start": "PORT=8080 react-scripts start",
     "prebuild": "rimraf dist",
     "build": "react-scripts build",
     "postbuild": "mv ./build dist",


### PR DESCRIPTION
Change the frontend port from 3001 to 8080. 
Ideally, it should run as the go server. 
But keeping the port number the same will avoid adding additional redirect URL. 