### PR TITLE
Modify existing APIs to use JWT token

### DIFF
--- a/cmd/jobsgowhere.go
+++ b/cmd/jobsgowhere.go
@@ -20,7 +20,7 @@ func ConfigureRoutes(router *gin.Engine, db *sql.DB) {
 	api.Use(oauth.AuthMiddleware())
 	api.GET("/jobs/:pageNumber", jc.GetJobs)
 	api.GET("/jobsbyid/:id", jc.GetJobByID)
-	api.GET("/favouritejobs/:id", jc.GetFavouriteJobs)
+	api.GET("/favouritejobs/", jc.GetFavouriteJobs)
 	api.POST("/job/", jc.PostJob)
 
 	tc := talent.NewController(db)

--- a/internal/job/repository.go
+++ b/internal/job/repository.go
@@ -14,8 +14,8 @@ const errSqlNoRows = "sql: no rows in result set"
 type Repository interface {
 	GetJobByID(ctx context.Context, jobID string) (*models.Job, error)
 	GetJobs(ctx context.Context, pageNumber int, itemsPerPage int) (models.JobSlice, error)
-	GetFavouriteJobs(ctx context.Context, personID string) (models.JobSlice, error)
-	CreateJob(ctx context.Context, params CreateJobParams) (*models.Job, error)
+	GetFavouriteJobs(ctx context.Context, iamID string) (models.JobSlice, error)
+	CreateJob(ctx context.Context, iamID string, params CreateJobParams) (*models.Job, error)
 }
 
 type jobRepository struct {
@@ -54,17 +54,20 @@ func (repo *jobRepository) GetJobs(ctx context.Context, pageNumber int, itemsPer
 		qm.OrderBy(models.JobColumns.CreatedAt+" DESC")).All(ctx, repo.executor)
 }
 
-func (repo *jobRepository) GetFavouriteJobs(ctx context.Context, personID string) (models.JobSlice, error) {
-	uuid, err := uuid.FromString(personID)
+func (repo *jobRepository) GetFavouriteJobs(ctx context.Context, iamID string) (models.JobSlice, error) {
+	person, err := models.People(
+		models.PersonWhere.IamID.EQ(iamID)).One(ctx, repo.executor)
+
 	if err != nil {
 		return nil, err
 	}
+
 	jobs, err := models.Jobs(
 		qm.Load(models.JobRels.Person),
 		qm.Load(models.JobRels.Person+"."+models.PersonRels.JobProvider),
 		qm.Load(models.JobRels.Person+"."+models.PersonRels.PersonProfiles),
 		qm.InnerJoin(models.TableNames.JobSeekerFav+" jsf ON job.id = jsf.job_id"),
-		qm.Where("jsf.person_id = ?", uuid.String()),
+		qm.Where("jsf.person_id = ?", person.ID),
 	).All(ctx, repo.executor)
 
 	if err != nil {
@@ -76,25 +79,17 @@ func (repo *jobRepository) GetFavouriteJobs(ctx context.Context, personID string
 	return jobs, nil
 }
 
-func (repo *jobRepository) CreateJob(ctx context.Context, params CreateJobParams) (*models.Job, error) {
+func (repo *jobRepository) CreateJob(ctx context.Context, iamID string, params CreateJobParams) (*models.Job, error) {
 	u1, err := uuid.NewV4()
 
 	if err != nil {
 		return nil, err
 	}
 
-	u2, err := uuid.FromString(params.PersonID)
+	person, err := models.People(
+		models.PersonWhere.IamID.EQ(iamID)).One(ctx, repo.executor)
 
 	if err != nil {
-		return nil, err
-	}
-
-	jobExists, err := models.JobExists(ctx, repo.executor, u2.String())
-
-	if err != nil && jobExists == false {
-		if err.Error() == errSqlNoRows {
-			return nil, nil
-		}
 		return nil, err
 	}
 
@@ -104,7 +99,7 @@ func (repo *jobRepository) CreateJob(ctx context.Context, params CreateJobParams
 	jobPost.Location = params.City
 	jobPost.ID = u1.String()
 	jobPost.Status = 1 // default to active
-	jobPost.PersonID = u2.String()
+	jobPost.PersonID = person.ID
 
 	err = jobPost.Insert(ctx, repo.executor, boil.Infer())
 

--- a/internal/job/service.go
+++ b/internal/job/service.go
@@ -30,8 +30,8 @@ func (h HuntingMode) String() string {
 type Service interface {
 	GetJobByID(ctx context.Context, jobID string) (JobPost, error)
 	GetJobs(ctx context.Context, pageNumber int, itemsPerPage int) ([]JobPost, error)
-	GetFavouriteJobs(ctx context.Context, personID string) ([]JobPost, error)
-	CreateJob(ctx context.Context, params CreateJobParams) (JobPost, error)
+	GetFavouriteJobs(ctx context.Context, iamID string) ([]JobPost, error)
+	CreateJob(ctx context.Context, iamID string, params CreateJobParams) (JobPost, error)
 }
 
 type jobService struct {
@@ -60,8 +60,8 @@ func (j *jobService) GetJobByID(ctx context.Context, jobID string) (JobPost, err
 	return jobPost, nil
 }
 
-func (j *jobService) GetFavouriteJobs(ctx context.Context, personID string) ([]JobPost, error) {
-	jobs, err := j.repo.GetFavouriteJobs(ctx, personID)
+func (j *jobService) GetFavouriteJobs(ctx context.Context, iamID string) ([]JobPost, error) {
+	jobs, err := j.repo.GetFavouriteJobs(ctx, iamID)
 	if err != nil {
 		return nil, err
 	}
@@ -73,8 +73,8 @@ func (j *jobService) GetFavouriteJobs(ctx context.Context, personID string) ([]J
 	return jobPosts, nil
 }
 
-func (j *jobService) CreateJob(ctx context.Context, params CreateJobParams) (JobPost, error) {
-	job, err := j.repo.CreateJob(ctx, params)
+func (j *jobService) CreateJob(ctx context.Context, iamID string, params CreateJobParams) (JobPost, error) {
+	job, err := j.repo.CreateJob(ctx, iamID, params)
 	if err != nil {
 		return JobPost{}, err
 	}

--- a/internal/message/controller.go
+++ b/internal/message/controller.go
@@ -28,6 +28,7 @@ func NewController(exec boil.ContextExecutor) Controller {
 }
 
 func (c *messageController) SendMessage(ginCtx *gin.Context) {
+	iamID := ginCtx.GetString("iam_id")
 	var sendMessageParams SendMessageParams
 	err := ginCtx.Bind(&sendMessageParams)
 
@@ -36,14 +37,14 @@ func (c *messageController) SendMessage(ginCtx *gin.Context) {
 		return
 	}
 
-	if strings.TrimSpace(sendMessageParams.FromID) == "" || strings.TrimSpace(sendMessageParams.ToID) == "" ||
-		strings.TrimSpace(sendMessageParams.Subject) == "" || strings.TrimSpace(sendMessageParams.Body) == "" {
+	if strings.TrimSpace(sendMessageParams.ToID) == "" || strings.TrimSpace(sendMessageParams.Subject) == "" ||
+		strings.TrimSpace(sendMessageParams.Body) == "" {
 		web.RespondError(ginCtx, http.StatusBadRequest, "not_enough_arguments", "Required parameters are missing")
 		return
 	}
 
 	err = c.service.SendMessage(ginCtx.Request.Context(), sendMessageParams.ToID,
-		sendMessageParams.FromID, sendMessageParams.Subject, sendMessageParams.Body)
+		iamID, sendMessageParams.Subject, sendMessageParams.Body)
 
 	if err != nil {
 		web.RespondError(ginCtx, http.StatusInternalServerError, "internal_error", err.Error())

--- a/internal/message/model.go
+++ b/internal/message/model.go
@@ -2,7 +2,6 @@ package message
 
 // SendMessageParams struct
 type SendMessageParams struct {
-	FromID  string `json:"from"`
 	ToID    string `json:"to"`
 	Subject string `json:"subject"`
 	Body    string `json:"body"`

--- a/internal/message/repository.go
+++ b/internal/message/repository.go
@@ -14,7 +14,7 @@ import (
 
 // Repository - message repository interface
 type Repository interface {
-	SendMessage(ctx context.Context, toPersonID string, fromPersonID string, title string, message string) error
+	SendMessage(ctx context.Context, toPersonID string, senderIamID string, title string, message string) error
 }
 
 type messageRepository struct {
@@ -22,7 +22,7 @@ type messageRepository struct {
 }
 
 func (repo *messageRepository) SendMessage(ctx context.Context, toPersonID string,
-	fromPersonID string, subject string, body string) error {
+	senderIamID string, subject string, body string) error {
 
 	toPerson, err := models.People(
 		models.PersonWhere.ID.EQ(toPersonID)).One(ctx, repo.executor)
@@ -32,7 +32,7 @@ func (repo *messageRepository) SendMessage(ctx context.Context, toPersonID strin
 	}
 
 	sender, err := models.People(
-		models.PersonWhere.ID.EQ(fromPersonID)).One(ctx, repo.executor)
+		models.PersonWhere.IamID.EQ(senderIamID)).One(ctx, repo.executor)
 
 	if err != nil {
 		return err

--- a/internal/message/service.go
+++ b/internal/message/service.go
@@ -5,7 +5,7 @@ import "context"
 // Service - message service interface
 type Service interface {
 	SendMessage(ctx context.Context, toPersonID string,
-		fromPersonID string, subject string, body string) error
+		senderIamID string, subject string, body string) error
 }
 
 type messageService struct {
@@ -13,9 +13,9 @@ type messageService struct {
 }
 
 func (m *messageService) SendMessage(ctx context.Context, toPersonID string,
-	fromPersonID string, subject string, body string) error {
+	senderIamID string, subject string, body string) error {
 
-	err := m.repo.SendMessage(ctx, toPersonID, fromPersonID, subject, body)
+	err := m.repo.SendMessage(ctx, toPersonID, senderIamID, subject, body)
 
 	if err != nil {
 		return err

--- a/internal/talent/controller.go
+++ b/internal/talent/controller.go
@@ -27,7 +27,6 @@ type talentController struct {
 
 // CreateTalentParams struct
 type CreateTalentParams struct {
-	PersonID       string `json:"person_id"`
 	Title          string `json:"title"`
 	Description    string `json:"description"`
 	CurrentCompany string `json:"current_company"`
@@ -80,6 +79,8 @@ func (c *talentController) GetTalents(ginCtx *gin.Context) {
 
 // create talent
 func (c *talentController) PostTalent(ginCtx *gin.Context) {
+	iamID := ginCtx.GetString("iam_id")
+
 	var createTalent CreateTalentParams
 	err := ginCtx.Bind(&createTalent)
 
@@ -88,13 +89,13 @@ func (c *talentController) PostTalent(ginCtx *gin.Context) {
 		return
 	}
 
-	if strings.TrimSpace(createTalent.PersonID) == "" || strings.TrimSpace(createTalent.Title) == "" ||
-		strings.TrimSpace(createTalent.Description) == "" || strings.TrimSpace(createTalent.City) == "" {
+	if strings.TrimSpace(createTalent.Title) == "" || strings.TrimSpace(createTalent.Description) == "" ||
+		strings.TrimSpace(createTalent.City) == "" {
 		web.RespondError(ginCtx, http.StatusBadRequest, "not_enough_arguments", "Required parameters are missing")
 		return
 	}
 
-	talent, err := c.service.CreateTalent(ginCtx.Request.Context(), createTalent)
+	talent, err := c.service.CreateTalent(ginCtx.Request.Context(), iamID, createTalent)
 
 	if err != nil {
 		web.RespondError(ginCtx, http.StatusInternalServerError, "internal_error", err.Error())

--- a/internal/talent/repository.go
+++ b/internal/talent/repository.go
@@ -16,7 +16,7 @@ const errSqlNoRows = "sql: no rows in result set"
 type Repository interface {
 	GetTalentByID(ctx context.Context, talentID string) (*models.JobSeeker, error)
 	GetTalents(ctx context.Context, pageNumber int, itemsPerPage int) (models.JobSeekerSlice, error)
-	CreateTalent(ctx context.Context, params CreateTalentParams) (*models.JobSeeker, error)
+	CreateTalent(ctx context.Context, iamID string, params CreateTalentParams) (*models.JobSeeker, error)
 }
 
 // talentRepository struct
@@ -54,25 +54,17 @@ func (repo *talentRepository) GetTalents(ctx context.Context, pageNumber int, it
 		qm.OrderBy(models.JobSeekerColumns.CreatedAt+" DESC")).All(ctx, repo.executor)
 }
 
-func (repo *talentRepository) CreateTalent(ctx context.Context, params CreateTalentParams) (*models.JobSeeker, error) {
+func (repo *talentRepository) CreateTalent(ctx context.Context, iamID string, params CreateTalentParams) (*models.JobSeeker, error) {
 	u1, err := uuid.NewV4()
 
 	if err != nil {
 		return nil, err
 	}
 
-	u2, err := uuid.FromString(params.PersonID)
+	person, err := models.People(
+		models.PersonWhere.IamID.EQ(iamID)).One(ctx, repo.executor)
 
 	if err != nil {
-		return nil, err
-	}
-
-	personExists, err := models.PersonExists(ctx, repo.executor, u2.String())
-
-	if err != nil && personExists == false {
-		if err.Error() == errSqlNoRows {
-			return nil, nil
-		}
 		return nil, err
 	}
 
@@ -82,7 +74,7 @@ func (repo *talentRepository) CreateTalent(ctx context.Context, params CreateTal
 	jobSeeker.Headline = null.StringFrom(params.Description)
 	jobSeeker.City = null.StringFrom(params.City)
 	jobSeeker.SeekingMode = null.IntFrom(1) // default to active
-	jobSeeker.PersonID = u2.String()
+	jobSeeker.PersonID = person.ID
 
 	err = jobSeeker.Insert(ctx, repo.executor, boil.Infer())
 

--- a/internal/talent/service.go
+++ b/internal/talent/service.go
@@ -27,7 +27,7 @@ func (h SeekingMode) String() string {
 type Service interface {
 	GetTalentByID(ctx context.Context, talentID string) (Talent, error)
 	GetTalents(ctx context.Context, pageNumber int, itemsPerPage int) ([]Talent, error)
-	CreateTalent(ctx context.Context, params CreateTalentParams) (Talent, error)
+	CreateTalent(ctx context.Context, iamID string, params CreateTalentParams) (Talent, error)
 }
 
 // talent service struct
@@ -57,8 +57,8 @@ func (j *talentService) GetTalentByID(ctx context.Context, talentID string) (Tal
 	return talentObj, nil
 }
 
-func (j *talentService) CreateTalent(ctx context.Context, params CreateTalentParams) (Talent, error) {
-	talent, err := j.repo.CreateTalent(ctx, params)
+func (j *talentService) CreateTalent(ctx context.Context, iamID string, params CreateTalentParams) (Talent, error) {
+	talent, err := j.repo.CreateTalent(ctx, iamID, params)
 	if err != nil {
 		return Talent{}, err
 	}


### PR DESCRIPTION
This will modify some of the existing APIs. 

* No need to pass `person_id` in the request body anymore
* Pass the JWT access_token in authentication header 

This modifies the following 4 APIs.

* Create Job
* Create Talent
* Connect
* Get Favourite Jobs