### PR TITLE
Revert ports for dev environment

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	defer db.Close()
 
 	router.Use(cors.New(cors.Config{
-		AllowOrigins: []string{"http://localhost:8080"},
+		AllowOrigins: []string{"http://localhost:3001"},
 	}))
 
 	router.Use(func(ctx *gin.Context) {

--- a/ui/package.json
+++ b/ui/package.json
@@ -29,7 +29,7 @@
     "xstate": "^4.9.1"
   },
   "scripts": {
-    "start": "PORT=8080 react-scripts start",
+    "start": "PORT=3001 react-scripts start",
     "prebuild": "rimraf dist",
     "build": "react-scripts build",
     "postbuild": "mv ./build dist",


### PR DESCRIPTION
Revert earlier accidental changes to port:
- `start` script should start React app in development mode: port `3001`
- Server CORS AllowOrigins should include requests from React dev app