### PR TITLE
Profile API: Return missing fields

### DIFF
--- a/internal/person/model.go
+++ b/internal/person/model.go
@@ -17,8 +17,12 @@ type Person struct {
 	ID             string  `json:"id"`
 	FirstName      string  `json:"first_name"`
 	LastName       string  `json:"last_name"`
+	Headline       string  `json:"headline"`
+	Company        string  `json:"company"`
+	CompanyWebsite string  `json:"website"`
 	AvatarURL      string  `json:"avatar_url"`
-	CurrentCompany string  `json:"current_company,omitempty"`
+	Email          string  `json:"email"`
+	ProfileType    string  `json:"profile_type"`
 	Profile        Profile `json:"profiles,omitempty"`
 }
 

--- a/internal/person/repository.go
+++ b/internal/person/repository.go
@@ -16,8 +16,8 @@ const errSqlNoRows = "sql: no rows in result set"
 
 // Repository interface for person
 type Repository interface {
-	GetProfile(ctx context.Context, iamID string) (*models.PersonProfile, error)
-	CreateProfile(ctx context.Context, iamID string, params CreateProfileParams) (*models.PersonProfile, error)
+	GetProfile(ctx context.Context, iamID string) (*models.PersonProfile, *models.JobProvider, error)
+	CreateProfile(ctx context.Context, iamID string, params CreateProfileParams) (*models.PersonProfile, *models.JobProvider, error)
 }
 
 // personRepository struct
@@ -25,37 +25,46 @@ type personRepository struct {
 	executor boil.ContextExecutor
 }
 
-func (repo *personRepository) GetProfile(ctx context.Context, iamID string) (*models.PersonProfile, error) {
+func (repo *personRepository) GetProfile(ctx context.Context, iamID string) (*models.PersonProfile, *models.JobProvider, error) {
 	person, err := models.People(
 		qm.Load(models.PersonRels.PersonProfiles),
 		models.PersonWhere.IamID.EQ(iamID)).One(ctx, repo.executor)
 
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return nil, nil
+			return nil, nil, nil
 		}
-		return nil, err
+		return nil, nil, err
 	}
 
 	if len(person.R.PersonProfiles) == 0 {
-		return nil, errors.New("profile not found")
+		return nil, nil, errors.New("profile not found")
 	}
 
 	personProfile := person.R.PersonProfiles[0]
-	return personProfile, err
+
+	jobProvider, err := models.JobProviders(
+		models.JobProviderWhere.PersonID.EQ(person.ID)).One(ctx, repo.executor)
+
+	if err != nil {
+		jobProvider := &models.JobProvider{}
+		return personProfile, jobProvider, nil
+	}
+
+	return personProfile, jobProvider, err
 }
 
-func (repo *personRepository) CreateProfile(ctx context.Context, iamID string, params CreateProfileParams) (*models.PersonProfile, error) {
+func (repo *personRepository) CreateProfile(ctx context.Context, iamID string, params CreateProfileParams) (*models.PersonProfile, *models.JobProvider, error) {
 	u1, err := uuid.NewV4()
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	u2, err := uuid.NewV4()
 
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	person, err := models.People(
@@ -77,12 +86,14 @@ func (repo *personRepository) CreateProfile(ctx context.Context, iamID string, p
 			err = person.Insert(ctx, repo.executor, boil.Infer())
 
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		} else {
-			return nil, err
+			return nil, nil, err
 		}
 	}
+
+	jobProvider := &models.JobProvider{}
 
 	if person.R == nil || len(person.R.PersonProfiles) == 0 {
 		personProfile := &models.PersonProfile{
@@ -94,7 +105,7 @@ func (repo *personRepository) CreateProfile(ctx context.Context, iamID string, p
 		err = personProfile.Insert(ctx, repo.executor, boil.Infer())
 
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		if params.ProfileType == Recruiter.String() {
@@ -108,7 +119,7 @@ func (repo *personRepository) CreateProfile(ctx context.Context, iamID string, p
 			err = jobProvider.Insert(ctx, repo.executor, boil.Infer())
 
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
@@ -117,12 +128,20 @@ func (repo *personRepository) CreateProfile(ctx context.Context, iamID string, p
 			models.PersonProfileWhere.ID.EQ(u1.String())).One(ctx, repo.executor)
 
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		return profile, nil
+		return profile, jobProvider, nil
 	}
 
 	personProfile := person.R.PersonProfiles[0]
-	return personProfile, err
+
+	jobProviderObj, err := models.JobProviders(
+		models.JobProviderWhere.PersonID.EQ(person.ID)).One(ctx, repo.executor)
+
+	if err != nil {
+		return personProfile, jobProvider, nil
+	}
+
+	return personProfile, jobProviderObj, err
 }

--- a/internal/person/service.go
+++ b/internal/person/service.go
@@ -18,57 +18,55 @@ type personService struct {
 }
 
 func (p *personService) GetProfile(ctx context.Context, iamID string) (Person, error) {
-	var person Person
-	personProfile, jobProvider, err := p.repo.GetProfile(ctx, iamID)
+	var personObj Person
+	person, err := p.repo.GetProfile(ctx, iamID)
 	if err != nil {
 		return Person{}, err
 	}
-	if personProfile != nil {
-		person = convert(personProfile, jobProvider)
-	}
-	return person, nil
-}
 
-func (p *personService) CreateProfile(ctx context.Context, iamID string, params CreateProfileParams) (Person, error) {
-	person, jobProvider, err := p.repo.CreateProfile(ctx, iamID, params)
-	if err != nil {
-		return Person{}, err
-	}
-	personObj := convert(person, jobProvider)
+	personObj = convert(person)
+
 	return personObj, nil
 }
 
-func convert(profile *models.PersonProfile, jobProvider *models.JobProvider) Person {
-	println(jobProvider.Title)
+func (p *personService) CreateProfile(ctx context.Context, iamID string, params CreateProfileParams) (Person, error) {
+	person, err := p.repo.CreateProfile(ctx, iamID, params)
+	if err != nil {
+		return Person{}, err
+	}
+	personObj := convert(person)
+	return personObj, nil
+}
 
-	if len(jobProvider.Title) > 0 {
+func convert(person *models.Person) Person {
+	if person.R.JobProvider != nil {
 		return Person{
-			ID:             profile.PersonID,
-			FirstName:      profile.R.Person.FirstName.String,
-			LastName:       profile.R.Person.LastName.String,
-			AvatarURL:      profile.R.Person.AvatarURL.String,
-			Email:          profile.R.Person.Email,
-			Company:        profile.R.Person.CurrentCompany.String,
-			Headline:       jobProvider.Title,
-			CompanyWebsite: jobProvider.WebsiteURL.String,
+			ID:             person.ID,
+			FirstName:      person.FirstName.String,
+			LastName:       person.LastName.String,
+			AvatarURL:      person.AvatarURL.String,
+			Email:          person.Email,
+			Company:        person.CurrentCompany.String,
+			Headline:       person.R.JobProvider.Title,
+			CompanyWebsite: person.R.JobProvider.WebsiteURL.String,
 			ProfileType:    Recruiter.String(),
 			Profile: Profile{
-				LinkedIn: profile.ProfileURL,
+				LinkedIn: person.R.PersonProfiles[0].ProfileURL,
 			},
 		}
 	} else {
 		return Person{
-			ID:             profile.PersonID,
-			FirstName:      profile.R.Person.FirstName.String,
-			LastName:       profile.R.Person.LastName.String,
-			AvatarURL:      profile.R.Person.AvatarURL.String,
-			Email:          profile.R.Person.Email,
-			Company:        profile.R.Person.CurrentCompany.String,
+			ID:             person.ID,
+			FirstName:      person.FirstName.String,
+			LastName:       person.LastName.String,
+			AvatarURL:      person.AvatarURL.String,
+			Email:          person.Email,
+			Company:        person.CurrentCompany.String,
 			Headline:       "",
 			CompanyWebsite: "",
 			ProfileType:    Seeker.String(),
 			Profile: Profile{
-				LinkedIn: profile.ProfileURL,
+				LinkedIn: person.R.PersonProfiles[0].ProfileURL,
 			},
 		}
 	}

--- a/internal/person/service.go
+++ b/internal/person/service.go
@@ -19,34 +19,57 @@ type personService struct {
 
 func (p *personService) GetProfile(ctx context.Context, iamID string) (Person, error) {
 	var person Person
-	personProfile, err := p.repo.GetProfile(ctx, iamID)
+	personProfile, jobProvider, err := p.repo.GetProfile(ctx, iamID)
 	if err != nil {
 		return Person{}, err
 	}
 	if personProfile != nil {
-		person = convert(personProfile)
+		person = convert(personProfile, jobProvider)
 	}
 	return person, nil
 }
 
 func (p *personService) CreateProfile(ctx context.Context, iamID string, params CreateProfileParams) (Person, error) {
-	person, err := p.repo.CreateProfile(ctx, iamID, params)
+	person, jobProvider, err := p.repo.CreateProfile(ctx, iamID, params)
 	if err != nil {
 		return Person{}, err
 	}
-	personObj := convert(person)
+	personObj := convert(person, jobProvider)
 	return personObj, nil
 }
 
-func convert(profile *models.PersonProfile) Person {
-	return Person{
-		ID:             profile.PersonID,
-		FirstName:      profile.R.Person.FirstName.String,
-		LastName:       profile.R.Person.LastName.String,
-		AvatarURL:      profile.R.Person.AvatarURL.String,
-		CurrentCompany: profile.R.Person.CurrentCompany.String,
-		Profile: Profile{
-			LinkedIn: profile.ProfileURL,
-		},
+func convert(profile *models.PersonProfile, jobProvider *models.JobProvider) Person {
+	println(jobProvider.Title)
+
+	if len(jobProvider.Title) > 0 {
+		return Person{
+			ID:             profile.PersonID,
+			FirstName:      profile.R.Person.FirstName.String,
+			LastName:       profile.R.Person.LastName.String,
+			AvatarURL:      profile.R.Person.AvatarURL.String,
+			Email:          profile.R.Person.Email,
+			Company:        profile.R.Person.CurrentCompany.String,
+			Headline:       jobProvider.Title,
+			CompanyWebsite: jobProvider.WebsiteURL.String,
+			ProfileType:    Recruiter.String(),
+			Profile: Profile{
+				LinkedIn: profile.ProfileURL,
+			},
+		}
+	} else {
+		return Person{
+			ID:             profile.PersonID,
+			FirstName:      profile.R.Person.FirstName.String,
+			LastName:       profile.R.Person.LastName.String,
+			AvatarURL:      profile.R.Person.AvatarURL.String,
+			Email:          profile.R.Person.Email,
+			Company:        profile.R.Person.CurrentCompany.String,
+			Headline:       "",
+			CompanyWebsite: "",
+			ProfileType:    Seeker.String(),
+			Profile: Profile{
+				LinkedIn: profile.ProfileURL,
+			},
+		}
 	}
 }


### PR DESCRIPTION
Return missing fields from Profile API. 

* In addition to the missing fields `current_company` has been changed to `company` 
* The LinkedIn Profile URL is hard to get with the scopes we have. I have requested LinkedIn for additional scope but we need to come up with an alternative if that takes longer. 


## Old Response
```
{
    "id": "0b7101c0-a246-4ed9-8dfc-acb75a5d88e8",
    "first_name": "Subhransu",
    "last_name": "Behera",
    "current_company": "SPGroup",
    "avatar_url": "https://media-exp1.licdn.com/dms/image/C4E03AQGxSP9YsUBGPQ/profile-displayphoto-shrink_800_800/0?e=1597881600&v=beta&t=GnYnoXs-O4q3TuKPI8Ov4kgzCUhtwgq22D_cC5T-Peg",
    "profiles": {
        "linkedin": "dfds"
    }
}
```


## New Response
```
{
    "id": "0b7101c0-a246-4ed9-8dfc-acb75a5d88e8",
    "first_name": "Subhransu",
    "last_name": "Behera",
    "headline": "Developer",
    "company": "SPGroup",
    "website": "spdigital.io",
    "avatar_url": "https://media-exp1.licdn.com/dms/image/C4E03AQGxSP9YsUBGPQ/profile-displayphoto-shrink_800_800/0?e=1597881600&v=beta&t=GnYnoXs-O4q3TuKPI8Ov4kgzCUhtwgq22D_cC5T-Peg",
    "email": "subh+5@subhb.org",
    "profile_type": "Recruiter",
    "profiles": {
        "linkedin": "dfds"
    }
}
```