### PR TITLE
Bug modal component

### DIFF
--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -74,11 +74,11 @@ type Props = {
 };
 
 const Modal: React.FC<Props> = ({ id, category, onHide }) => {
-  const modalRef = React.useRef<HTMLDivElement | null>(null);
+  const [modalNode, setModalNode] = React.useState<HTMLDivElement | null>(null);
   React.useEffect(() => {
     const node = document.createElement("div");
     document.body.appendChild(node);
-    modalRef.current = node;
+    setModalNode(node);
   }, []);
 
   function markup() {
@@ -108,9 +108,8 @@ const Modal: React.FC<Props> = ({ id, category, onHide }) => {
       </ModalBackground>
     );
   }
-
-  if (!modalRef.current) return null;
-  return createPortal(markup(), modalRef.current);
+  if (!modalNode) return null;
+  return createPortal(markup(), modalNode);
 };
 
 export { Modal };

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import { createPortal } from 'react-dom'
-import styled from 'styled-components'
+import { createPortal } from "react-dom";
+import styled from "styled-components";
+
 import Button from "../components/Button";
-import { toast } from "../components/useToast"
+import { toast } from "../components/useToast";
 import JobsGoWhereApiClient from "../shared/services/JobsGoWhereApiClient";
 
 const ModalBackground = styled.div`
@@ -16,7 +17,7 @@ const ModalBackground = styled.div`
   top: 0;
   left: 0;
   z-index: 3;
-`
+`;
 
 const ModalContainer = styled.div`
   width: 368px;
@@ -25,21 +26,21 @@ const ModalContainer = styled.div`
   margin: 0 auto;
   border-radius: 14px;
   padding: 1rem;
-`
+`;
 
 const ModalTitle = styled.h4`
   font-size: 1.25rem;
   font-weight: 600;
   margin: 0.625rem 0 0 0;
   text-align: center;
-`
+`;
 
 const ModalDescription = styled.p`
   font-size: 1rem;
   line-height: 1.375rem;
   margin: 1rem 0;
   text-align: center;
-`
+`;
 
 const Buttons = styled.div`
   display: flex;
@@ -60,52 +61,64 @@ const handleDeletePost = async (id: string, category: string) => {
       method: "delete",
       headers: {
         "Content-Type": "application/json",
-      }
+      },
     });
-    toast("✨ Poof! We deleted the post for you! ")
+    toast("✨ Poof! We deleted the post for you! ");
     setTimeout(() => {
       window.location.reload();
     }, 1000);
   } catch (error) {
     console.error(error.toJSON());
-    toast("😭 There was an error deleting your post.")
+    toast("😭 There was an error deleting your post.");
     throw error;
   }
-}
+};
 
 const Modal = () => {
-  const modalRef = React.useRef < HTMLDivElement | null > (null)
-  const [shouldShowModal, setShowModal] = React.useState(false)
-  const [postID, setPostID] = React.useState("")
-  const [category, setCategory] = React.useState("")
-  showModal = setShowModal
-  postToDelete = setPostID
-  postCategory = setCategory
+  const modalRef = React.useRef<HTMLDivElement | null>(null);
+  const [shouldShowModal, setShowModal] = React.useState(false);
+  const [postID, setPostID] = React.useState("");
+  const [category, setCategory] = React.useState("");
+  showModal = setShowModal;
+  postToDelete = setPostID;
+  postCategory = setCategory;
   React.useEffect(() => {
-    const node = document.createElement('div')
-    document.body.appendChild(node)
-    modalRef.current = node
-  }, [])
+    const node = document.createElement("div");
+    document.body.appendChild(node);
+    modalRef.current = node;
+  }, []);
 
-  function markup () {
+  function markup() {
     if (!shouldShowModal) return null;
     return (
       <ModalBackground>
         <ModalContainer>
           <ModalTitle>Delete Post</ModalTitle>
-          <ModalDescription>Posts that are deleted can never be recovered. Do you want to continue?</ModalDescription>
+          <ModalDescription>
+            Posts that are deleted can never be recovered. Do you want to continue?
+          </ModalDescription>
           <Buttons>
-            <Button fullWidth onClick={() => setShowModal(false)}>Cancel</Button>
-            <Button fullWidth primary onClick={() => { setShowModal(false); handleDeletePost(postID, category)}}>Delete</Button>
+            <Button fullWidth onClick={() => setShowModal(false)}>
+              Cancel
+            </Button>
+            <Button
+              fullWidth
+              primary
+              onClick={() => {
+                setShowModal(false);
+                handleDeletePost(postID, category);
+              }}
+            >
+              Delete
+            </Button>
           </Buttons>
         </ModalContainer>
       </ModalBackground>
-    )
+    );
   }
 
-  if (!modalRef.current) return null
-  return createPortal(markup(), modalRef.current)
+  if (!modalRef.current) return null;
+  return createPortal(markup(), modalRef.current);
+};
 
-}
-
-export { Modal, showModal, postToDelete, postCategory }
+export { Modal, showModal, postToDelete, postCategory };

--- a/ui/src/components/Modal.tsx
+++ b/ui/src/components/Modal.tsx
@@ -50,18 +50,11 @@ const Buttons = styled.div`
   }
 `;
 
-let showModal: React.Dispatch<boolean>;
-let postToDelete: React.Dispatch<string>;
-let postCategory: React.Dispatch<string>;
-
 const handleDeletePost = async (id: string, category: string) => {
   try {
     await JobsGoWhereApiClient({
       url: `${process.env.REACT_APP_API}/${category}byid/${id}`,
       method: "delete",
-      headers: {
-        "Content-Type": "application/json",
-      },
     });
     toast("✨ Poof! We deleted the post for you! ");
     setTimeout(() => {
@@ -74,14 +67,14 @@ const handleDeletePost = async (id: string, category: string) => {
   }
 };
 
-const Modal = () => {
+type Props = {
+  id: string;
+  category: string;
+  onHide: () => void;
+};
+
+const Modal: React.FC<Props> = ({ id, category, onHide }) => {
   const modalRef = React.useRef<HTMLDivElement | null>(null);
-  const [shouldShowModal, setShowModal] = React.useState(false);
-  const [postID, setPostID] = React.useState("");
-  const [category, setCategory] = React.useState("");
-  showModal = setShowModal;
-  postToDelete = setPostID;
-  postCategory = setCategory;
   React.useEffect(() => {
     const node = document.createElement("div");
     document.body.appendChild(node);
@@ -89,7 +82,6 @@ const Modal = () => {
   }, []);
 
   function markup() {
-    if (!shouldShowModal) return null;
     return (
       <ModalBackground>
         <ModalContainer>
@@ -98,15 +90,15 @@ const Modal = () => {
             Posts that are deleted can never be recovered. Do you want to continue?
           </ModalDescription>
           <Buttons>
-            <Button fullWidth onClick={() => setShowModal(false)}>
+            <Button fullWidth onClick={onHide}>
               Cancel
             </Button>
             <Button
               fullWidth
               primary
               onClick={() => {
-                setShowModal(false);
-                handleDeletePost(postID, category);
+                onHide();
+                handleDeletePost(id, category);
               }}
             >
               Delete
@@ -121,4 +113,4 @@ const Modal = () => {
   return createPortal(markup(), modalRef.current);
 };
 
-export { Modal, showModal, postToDelete, postCategory };
+export { Modal };

--- a/ui/src/shared/components/PostDetail.tsx
+++ b/ui/src/shared/components/PostDetail.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 
 import Button from "../../components/Button";
 import { Menu, StyledMenuItem, StyledMenuList } from "../../components/Menu";
-import { Modal, postCategory, postToDelete, showModal } from "../../components/Modal";
+import { Modal } from "../../components/Modal";
 import { setMessageDialog, showMessageDialog } from "../../components/useMessageDialog";
 import { toast } from "../../components/useToast";
 import Auth0Context from "../../contexts/Auth0";
@@ -77,6 +77,10 @@ const PostDetail: React.FC<PostDetailProps> = function (props) {
   const postContext = usePost();
   const auth0Context = React.useContext(Auth0Context);
   const [profile, setProfile] = React.useState<FullProfile>();
+  const [modalVisible, setModalVisible] = React.useState(false);
+  const [postToDelete, setPostToDelete] = React.useState<{ id: string; category: string } | null>(
+    null,
+  );
 
   React.useEffect(() => {
     if (context?.profile) {
@@ -115,9 +119,8 @@ const PostDetail: React.FC<PostDetailProps> = function (props) {
   };
 
   const displayModal = (id: string, category: string) => {
-    postToDelete(id);
-    postCategory(category);
-    showModal(true);
+    setPostToDelete({ id, category });
+    setModalVisible(true);
   };
 
   const editPost = () => {
@@ -171,7 +174,9 @@ const PostDetail: React.FC<PostDetailProps> = function (props) {
           Connect with {user.first_name}
         </Button>
       </ButtonContainer>
-      <Modal></Modal>
+      {modalVisible && postToDelete && (
+        <Modal {...postToDelete} onHide={() => setModalVisible(false)} />
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
### Refactor Modal component
- Move show/hide logic into component that is using the modal (PostDetail), rather than embedding it into Modal and exporting a toggle function.
- Pass post `id` and `category` as props to Modal, rather than maintaining that state in the modal and exporting setter functions.

### Room to improve
- Delete feature and Modal are tied together. Okay for now, but need to refactor again if Modal needs to be used somewhere else.
- Accessibility and UX
  - Autofocus on button in Modal
  - Click background to close
  - Press ESC key to close
