### PR TITLE
Chore: Update regex to enforce URLs require either http/https

### DIFF
--- a/ui/src/screens/Post/components/NewPostForm.tsx
+++ b/ui/src/screens/Post/components/NewPostForm.tsx
@@ -153,7 +153,7 @@ const NewPostForm: React.FC = () => {
               ref={register({
                 required: "Please enter a job link in this format (e.g. https://jobsgowhere.com)",
                 pattern: {
-                  value: /[(http(s)?):\/\/(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/,
+                  value: /(http(s)?):\/\/[(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/,
                   message: "Please enter a valid job link (e.g. https://jobsgowhere.com)",
                 },
               })}

--- a/ui/src/screens/Profile/components/Edit.tsx
+++ b/ui/src/screens/Profile/components/Edit.tsx
@@ -3,7 +3,7 @@ import { SubmitHandler, useForm } from "react-hook-form";
 import styled from "styled-components";
 
 import Button from "../../../components/Button";
-import { Fieldset, Hint, Label, Radio, TextInput } from "../../../components/FormFields";
+import { Fieldset, Hint, Label, Radio, TextInput, InputErrorMessage } from "../../../components/FormFields";
 import JobsGoWhereApiClient from "../../../shared/services/JobsGoWhereApiClient";
 import { Auth0Profile, FullProfile } from "../../../types";
 import ProfileImage from "./ProfileImage";
@@ -162,9 +162,17 @@ const Edit: React.FC<ProfileEditProps> = ({ profile, newUser, handleCancelEdit }
               id="company-website"
               name="website"
               defaultValue={website}
-              ref={register}
+              ref={register({
+                required: "Please enter a website link in this format (e.g. https://jobsgowhere.com)",
+                pattern: {
+                  value: /(http(s)?):\/\/[(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/,
+                  message: "Please enter a valid website link (e.g. https://jobsgowhere.com)",
+                },
+              })}
               onChange={(e) => setWebsite(e.target.value)}
+              error={!!errors.website}
             />
+            {errors.website && <InputErrorMessage>{errors.website.message}</InputErrorMessage>}
             <Hint>
               Include a company link for potential candiates to learn more about your company
             </Hint>
@@ -190,9 +198,17 @@ const Edit: React.FC<ProfileEditProps> = ({ profile, newUser, handleCancelEdit }
               id="seeker-website"
               name="website"
               defaultValue={website}
-              ref={register}
+              ref={register({
+                required: "Please enter a website link in this format (e.g. https://jobsgowhere.com)",
+                pattern: {
+                  value: /(http(s)?):\/\/[(www\.)?a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/,
+                  message: "Please enter a valid website link (e.g. https://jobsgowhere.com)",
+                },
+              })}
               onChange={(e) => setWebsite(e.target.value)}
+              error={!!errors.website}
             />
+            {errors.website && <InputErrorMessage>{errors.website.message}</InputErrorMessage>}
             <Hint>Include a link for potential companies to learn more about you.</Hint>
           </Fieldset>
         </>


### PR DESCRIPTION
Description
---
- Update regex to enforce URLs require either http/https
- Display error messages when URL criteria not met

Related Issues
---
- https://github.com/jobsgowhere/jobsgowhere/issues/166
- https://github.com/jobsgowhere/jobsgowhere/issues/158

Screenshots
---
![Screenshot 2020-10-30 at 1 39 18 AM](https://user-images.githubusercontent.com/6391234/97612024-da2d3100-1a51-11eb-83e3-bb77f0fe90b5.png)
![Screenshot 2020-10-30 at 1 39 26 AM](https://user-images.githubusercontent.com/6391234/97612030-dbf6f480-1a51-11eb-8ae8-d626630d39d9.png)
![Screenshot 2020-10-30 at 1 39 38 AM](https://user-images.githubusercontent.com/6391234/97612039-ddc0b800-1a51-11eb-9873-052001a18edf.png)
