### PR TITLE
Chore - Disable email field from editing

### DIFF
--- a/ui/src/screens/Profile/components/Edit.tsx
+++ b/ui/src/screens/Profile/components/Edit.tsx
@@ -232,6 +232,7 @@ const Edit: React.FC<ProfileEditProps> = ({ profile, newUser, handleCancelEdit }
           id="email"
           name="email"
           defaultValue={email}
+          disabled
           ref={register({
             required: true,
             pattern: /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,


### PR DESCRIPTION
Disable email on registration
<img width="554" alt="Screenshot 2020-11-13 at 12 18 25 PM" src="https://user-images.githubusercontent.com/6391234/99063292-4164ec80-25df-11eb-9d24-03dfe0c148c2.png">

After registration, disabled email field for edit profile
<img width="520" alt="Screenshot 2020-11-13 at 6 37 52 PM" src="https://user-images.githubusercontent.com/6391234/99063452-81c46a80-25df-11eb-9a2c-e3f7d116edf8.png">
