### PR TITLE
Fix initial profile creation failing

### DIFF
--- a/ui/src/screens/Profile/components/Edit.tsx
+++ b/ui/src/screens/Profile/components/Edit.tsx
@@ -71,7 +71,7 @@ const Edit: React.FC<ProfileEditProps> = ({ profile, newUser, handleCancelEdit }
       await JobsGoWhereApiClient({
         url: `${process.env.REACT_APP_API}/profile`,
         method: newUser ? "post" : "put",
-        data: values,
+        data: { ...values, email }, // add email value into request payload since email field is disabled
       });
       window.location.reload();
     } catch (error) {


### PR DESCRIPTION
In #184, the profile email field was set to `disabled` to prevent user changing it.
Unfortunately this had a side effect of removing the value from the submitted payload, causing the server to respond with "incomplete params" error. This fix manually adds it back.
