### PR TITLE
Fix incomplete headline text if user.company not available

### DIFF
--- a/ui/src/shared/components/Post.tsx
+++ b/ui/src/shared/components/Post.tsx
@@ -71,7 +71,8 @@ const Post: React.FC<PostProps> = function (props) {
                   {user.first_name} {user.last_name}
                 </Name>
                 <Headline>
-                  {user.job_title} at {user.company}
+                  {user.job_title}
+                  {Boolean(user.company) && `at ${user.company}`}
                 </Headline>
               </div>
             </InfoHeader>


### PR DESCRIPTION
Fix post headline ending abruptly (eg. "Software engineer at") when `user.company` is not available.
![image](https://user-images.githubusercontent.com/3888250/99766903-031a8080-2b3d-11eb-8927-d704aacd250c.png)
