### PR TITLE
Fix missing space for job posting headline

### DIFF
--- a/ui/src/shared/components/Post.tsx
+++ b/ui/src/shared/components/Post.tsx
@@ -72,7 +72,7 @@ const Post: React.FC<PostProps> = function (props) {
                 </Name>
                 <Headline>
                   {user.job_title}
-                  {Boolean(user.company) && `at ${user.company}`}
+                  {Boolean(user.company) && ` at ${user.company}`}
                 </Headline>
               </div>
             </InfoHeader>


### PR DESCRIPTION
Fixed missing space before "at":

![image](https://user-images.githubusercontent.com/3888250/99874389-a1ccdd00-2c22-11eb-9ec1-d5eeac1f4aef.png)
