### PR TITLE
Update New Post title default value with prefill text

### DIFF
--- a/ui/src/screens/Post/components/NewPostForm.tsx
+++ b/ui/src/screens/Post/components/NewPostForm.tsx
@@ -132,8 +132,14 @@ const NewPostForm: React.FC = () => {
           <TextInput
             id="title"
             name="title"
-            key={isEditMode.toString()}
-            defaultValue={isEditMode ? postContext.post?.title : ""}
+            key={`${isEditMode.toString()}-${watchPostType}`}
+            defaultValue={
+              isEditMode
+                ? postContext.post?.title
+                : watchPostType === "talent"
+                ? "I'm seeking a role as "
+                : "I'm hiring "
+            }
             ref={register({ required: "Please enter a post title" })}
             error={!!errors.title}
           />


### PR DESCRIPTION
Add prefill text to New Post title field.

**Hirer**
![image](https://user-images.githubusercontent.com/3888250/100641178-1665f100-3372-11eb-9a5c-eb449c3d702b.png)


**Seeker**
![image](https://user-images.githubusercontent.com/3888250/100641108-03ebb780-3372-11eb-8d09-5f42f5956129.png)



Resolves #201 