### PR TITLE
Fix DetailsContainer not scrollable on small viewports

### DIFF
--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -13,7 +13,7 @@ import { ToastContainer } from "./useToast";
 const Container = styled.div`
   background-color: var(--color-background);
   display: grid;
-  grid-template-rows: 3.5rem auto 100px;
+  grid-template-rows: 3.5rem auto 0;
   grid-template-columns: 100vw;
   grid-template-areas:
     "header"

--- a/ui/src/shared/components/DetailsContainer.tsx
+++ b/ui/src/shared/components/DetailsContainer.tsx
@@ -17,20 +17,26 @@ const StyledDetailsContainer = styled.div<{ active?: boolean; yOffset: number }>
 
   ${SCREENS.Down.Tablet} {
     width: 100%;
-    padding: 0 1rem;
+    padding: 0 1rem 1rem;
     position: absolute;
     top: ${(props) => props.yOffset}px;
+    overflow-y: scroll;
+    /* "3.5rem" below should match height of header in Layout.tsx  */
+    height: min(100%, 100vh - 3.5rem);
   }
 `;
 
 const DetailsContainer: React.FC<DetailsContainerProps> = function ({ active, onClick, children }) {
   const [yOffset, setYOffset] = React.useState(0);
+  const ref = React.useRef<HTMLDivElement>(null);
   React.useLayoutEffect(() => {
     setYOffset(window.scrollY);
     window.document.body.classList.toggle("mobile-scroll-lock", active);
+    // Ensure container scroll position is reset to top when Detail is opened
+    active && ref.current && ref.current.scrollTo(0, 0);
   }, [active]);
   return (
-    <StyledDetailsContainer onClick={onClick} active={active} yOffset={yOffset}>
+    <StyledDetailsContainer ref={ref} onClick={onClick} active={active} yOffset={yOffset}>
       {children}
     </StyledDetailsContainer>
   );

--- a/ui/src/shared/components/DetailsContainer.tsx
+++ b/ui/src/shared/components/DetailsContainer.tsx
@@ -20,7 +20,7 @@ const StyledDetailsContainer = styled.div<{ active?: boolean; yOffset: number }>
     padding: 0 1rem 1rem;
     position: absolute;
     top: ${(props) => props.yOffset}px;
-    overflow-y: scroll;
+    overflow-y: auto;
     /* "3.5rem" below should match height of header in Layout.tsx  */
     height: min(100%, 100vh - 3.5rem);
   }


### PR DESCRIPTION
As above. Did not fully test this screen when I implemented back then.

There's some issue with LICECap so I can't record a gif, so here's a screenshot ..
![image](https://user-images.githubusercontent.com/3888250/102494309-6b627080-40af-11eb-9d90-79381615403a.png)

Do pull this branch down if want to test 🙆‍♂️

Resolves #217 
