### PR TITLE
Fix GitHub spelling

### DIFF
--- a/docs/meetings/20200327-minutes.md
+++ b/docs/meetings/20200327-minutes.md
@@ -15,7 +15,7 @@
 
 ## Action Items
 
-- Create Github org & repo @subhransu
+- Create GitHub org & repo @subhransu
 - [#2](https://github.com/jobsgowhere/jobsgowhere/issues/2): Create the base and initial development environment (@kajalsinha is looking into it now)
 - [#3](https://github.com/jobsgowhere/jobsgowhere/issues/3): Create contribution guidelines (@subhransu can work on it)
 - [#4](https://github.com/jobsgowhere/jobsgowhere/issues/4): Figure out the frontend architecture

--- a/ui/src/components/Footer.tsx
+++ b/ui/src/components/Footer.tsx
@@ -46,7 +46,7 @@ export const FooterLinks: React.FC = function () {
           target="_blank"
           rel="noreferrer noopener"
         >
-          Github Repo
+          GitHub Repo
         </a>
       </li>
       <li>

--- a/ui/src/screens/Profile/components/Edit.tsx
+++ b/ui/src/screens/Profile/components/Edit.tsx
@@ -204,7 +204,7 @@ const Edit: React.FC<ProfileEditProps> = ({ profile, newUser, handleCancelEdit }
             <Hint>Give a headline of what you want others to see you as.</Hint>
           </Fieldset>
           <Fieldset>
-            <Label htmlFor="seeker-website">Website / Portfolio / Github</Label>
+            <Label htmlFor="seeker-website">Website / Portfolio / GitHub</Label>
             <TextInput
               id="seeker-website"
               name="website"


### PR DESCRIPTION
Minor capitalization fix: `Github` -> `GitHub`.

Great project! :+1: