### PR TITLE
Check and set detail view in Layout instead of sub components

### DIFF
--- a/ui/src/components/Header/NavBack.tsx
+++ b/ui/src/components/Header/NavBack.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
-import { useMobileViewContext } from "../../contexts/MobileView";
 import { SCREENS } from "../../media";
 
 const BackLink = styled.a`
@@ -26,11 +25,9 @@ const NavBack = () => {
   const history = useHistory();
   const split = history.location.pathname.split("/");
   split.pop();
-  const { setIsDetailView } = useMobileViewContext();
   return (
     <BackLink
       onClick={() => {
-        setIsDetailView(false);
         window.setTimeout(() => {
           history.push(split.join("/"));
         }, 150);

--- a/ui/src/components/Layout.tsx
+++ b/ui/src/components/Layout.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 import { Helmet } from "react-helmet";
+import { useLocation } from "react-router";
 import styled from "styled-components";
 
 import Auth0Context from "../contexts/Auth0";
+import { useMobileViewContext } from "../contexts/MobileView";
 import { useProfile } from "../contexts/Profile";
 import { SCREENS } from "../media";
 import Footer from "./Footer";
@@ -35,6 +37,10 @@ type LayoutProps = {
 const Layout: React.FC<LayoutProps> = function (props) {
   const { children } = props;
   const auth0Context = React.useContext(Auth0Context);
+  const location = useLocation<{ pathname: string }>().pathname;
+  const isActive = location.match(/\/(talents|jobs)\/[a-f0-9-]{36}/);
+  const { setIsDetailView } = useMobileViewContext();
+  setIsDetailView(Boolean(isActive));
   const profileContext = useProfile();
   if (!profileContext?.profile) {
     auth0Context?.state?.context?.client?.isAuthenticated().then((res) => {

--- a/ui/src/screens/Jobs/hooks/useJobsReducer.ts
+++ b/ui/src/screens/Jobs/hooks/useJobsReducer.ts
@@ -1,7 +1,6 @@
 import React from "react";
 import { useRouteMatch } from "react-router-dom";
 
-import { useMobileViewContext } from "../../../contexts/MobileView";
 import { PostInterface } from "../../../types";
 
 // State
@@ -127,7 +126,6 @@ interface JobsResponseData {
 
 export default function usePostsReducer(): [JobsState, JobsActions] {
   const [state, dispatch] = React.useReducer(JobsReducer, initialState);
-  const { setIsDetailView } = useMobileViewContext();
 
   const setActiveJob = React.useCallback((id?: string): void => {
     dispatch({ type: SET_ACTIVE_JOB, payload: id });
@@ -158,7 +156,6 @@ export default function usePostsReducer(): [JobsState, JobsActions] {
 
     if (id && state.activeJob?.id !== id) {
       setActiveJob(id);
-      setIsDetailView(true);
     } else if (!state.activeJob) {
       setActiveJob(state.jobs[0].id);
     }

--- a/ui/src/screens/Talents/hooks/useTalentsReducer.ts
+++ b/ui/src/screens/Talents/hooks/useTalentsReducer.ts
@@ -1,7 +1,6 @@
 import React from "react";
 import { useRouteMatch } from "react-router-dom";
 
-import { useMobileViewContext } from "../../../contexts/MobileView";
 import { PostInterface } from "../../../types";
 
 // State
@@ -103,7 +102,6 @@ interface TalentsResponseData {
 
 export default function useTalentsReducer(): [TalentsState, TalentsActions] {
   const [state, dispatch] = React.useReducer(TalentsReducer, initialState);
-  const { setIsDetailView } = useMobileViewContext();
 
   const setActiveTalent = React.useCallback((id?: string): void => {
     dispatch({ type: SET_ACTIVE_TALENT, payload: id });
@@ -130,7 +128,6 @@ export default function useTalentsReducer(): [TalentsState, TalentsActions] {
 
     if (id && state.activeTalent?.id !== id) {
       setActiveTalent(id);
-      setIsDetailView(true);
     } else if (!state.activeTalent) {
       setActiveTalent(state.talents[0].id);
     }

--- a/ui/src/shared/components/Post.tsx
+++ b/ui/src/shared/components/Post.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import { useHistory } from "react-router-dom";
 import styled from "styled-components";
 
-import { useMobileViewContext } from "../../contexts/MobileView";
 import { SCREENS } from "../../media";
 import { CategoryTypes, PostInterface } from "../../types";
 import boldSeekingHiring from "../lib/boldSeekingHiring";
@@ -52,11 +51,9 @@ const Post: React.FC<PostProps> = function (props) {
   const { active, data, category } = props;
   const { created_by: user } = data;
   const history = useHistory();
-  const { setIsDetailView } = useMobileViewContext();
   return (
     <a
       onClick={() => {
-        setIsDetailView(true);
         history.push(`/${category}/${data.id}`);
       }}
     >


### PR DESCRIPTION
## Bug
App state is not properly updated when using browser navigation, or clicking the logo at the top of Detail page.
This results in being "stuck" in the Detail page with the wrong navbar, if using the above methods to navigate.

## Fix
Check path and set this state in `Layout.tsx`, instead of doing it in individual subcomponents and not covering all cases.